### PR TITLE
Revert "Explicit support to generate doc and tag (#7)"

### DIFF
--- a/ubuntu/debian/rules
+++ b/ubuntu/debian/rules
@@ -35,13 +35,3 @@ override_dh_auto_test:
 
 override_dh_strip:
 	dh_strip -a --dbg-package=libgz-transport13-dbg
-
-# Execute doc creation to export at least the doxygen tag file
-override_dh_auto_build:
-	dh_auto_build -- doc
-	dh_auto_build
-
-override_dh_auto_install:
-	dh_auto_install
-	install -d debian/tmp/usr/share/gz/gz-transport13/
-	install ./obj-*/*.tag.xml debian/tmp/usr/share/gz/gz-transport13/


### PR DESCRIPTION
This reverts commit ae6c4f45499fcbef3e33db5f2a251e1824fb30d4.

Wrong version. Ionic is gz-transport14