### PR TITLE
Fix CPPZMQ CMake error on Ubuntu Noble

### DIFF
--- a/ubuntu/debian/control
+++ b/ubuntu/debian/control
@@ -36,6 +36,8 @@ Section: libdevel
 Depends: libgz-transport13 (= ${binary:Version}),
          uuid-dev,
          libzmq3-dev (>= 3.0.0),
+# CMake target CPPZMQ::CPPZMQ is declared in the new cppzmq-dev package in Ubuntu Noble onwards
+         cppzmq-dev | libzmq3-dev (>= 3.0.0),
          libgz-msgs10-dev,
          libgz-cmake3-dev,
          libgz-tools2-dev,

--- a/ubuntu/debian/control
+++ b/ubuntu/debian/control
@@ -24,6 +24,8 @@ Build-Depends: cmake,
                python3-pybind11,
                uuid-dev,
                libzmq3-dev (>= 3.0.0),
+# CMake target CPPZMQ::CPPZMQ is declared in the new cppzmq-dev package in Ubuntu Noble onwards
+               cppzmq-dev | libzmq3-dev (>= 3.0.0),
                libsqlite3-dev
 Vcs-Browser: https://github.com/gazebosim/gz-transport
 Vcs-Git: https://github.org/gazebo-release/gz-transport13-release


### PR DESCRIPTION
Starting with Ubuntu Noble, CMake target `CPPZMQ::CPPZMQ` is only declared in the new package `cppzmq-dev`. This breaks the building of packages that depend on `libgz-transport13-core-dev`.

See [my question on Robots SE](https://robotics.stackexchange.com/q/112711) for more details and an SSCE.

---

While this solution definitely works in principle, I am not sure I didn't do something stupid in the dpkg part.